### PR TITLE
Update Chai from 1.9.2 to 1.10.0.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "mocha": "~2.0.1",
     "requirejs": "~2.1.15",
-    "chai": "~1.9.2",
+    "chai": "~1.10.0",
     "jquery": "~2.1.1"
   }
 }


### PR DESCRIPTION
Changelog:

```
Merge pull request #297 from prodatakey/noopchainfunc
Merge pull request #300 from julienw/299-fix-getMessage-test
Fix #299: the test is defining global variables
Add a couple more unit tests
Add unit tests for chained terminating property asserts
Revise documentation wording
Add docs for function style NOOP asserts
Make the NOOP function a shared constant
Merge pull request #298 from dasilvacontin/negativeZeroLogging
why not more assertions
added test for inspecting -0
a more readable/simple condition statement, as pointed out by @keithamus
added check for logging negative zero
Change test to not trigger argument bug
Allows writing lint-friendly tests
readme: update contributors for 1.9.2
```

Ran unit tests, all seem to pass.
