### PR TITLE
Add `grunt test` to `npm test` so that it runs as well.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "prepublish": "bower install && grunt build --verbose",
-    "test": "node tests/promises-aplus-tests.js"
+    "test": "node tests/promises-aplus-tests.js && grunt test"
   },
   "directories": {
     "test": "tests"


### PR DESCRIPTION
I'm not sure if we need to install grunt globally, but since I don't (currently) have an easy way to spin up a VM, I'll put this up. I wouldn't merge it just yet, though.
