### PR TITLE
Add JSHint "lint" task to Gruntfile.js and run it when `npm test` is run.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,11 +1,10 @@
 {
-  "undef":true,
-  "unused":true,
-  "curly":true,
-  "indent":2,
-  "devel":true,
-  //"laxcasebreak":true,
-  "globals":{
+  "undef": true,
+  "unused": true,
+  "curly": true,
+  "indent": 2,
+  "devel": true,
+  "globals": {
     "require": true,
     "define": true,
     "$": true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,8 @@
 //
 // http://24ways.org/2013/grunt-is-not-weird-and-hard/
 //
+
+/* jshint node:true */
 module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON("package.json"),
@@ -93,10 +95,22 @@ module.exports = function(grunt) {
           }
         }
       }
+    },
+    jshint: {
+      all: [
+        "Gruntfile.js",
+        "src/**/*.js",
+        "tests/**/*.js"
+      ],
+      options: {
+        reporter: require("jshint-stylish"),
+        jshintrc: true
+      },
     }
   });
 
 
+  grunt.loadNpmTasks("grunt-contrib-jshint");
   grunt.loadNpmTasks("grunt-contrib-requirejs");
   grunt.loadNpmTasks("grunt-contrib-connect");
   grunt.loadNpmTasks("grunt-mocha");
@@ -104,5 +118,6 @@ module.exports = function(grunt) {
   grunt.registerTask("default", ["requirejs"]);
   grunt.registerTask("build", ["requirejs"]);
   grunt.registerTask("test", ["connect:test", "mocha:test"]);
+  grunt.registerTask("lint", ["jshint"]);
   grunt.registerTask("server", ["connect:keepalive"]);
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "main": "dist/spromise.js",
   "author": "Miguel Castillo <manchagnu@gmail.com>",
   "contributors": [
-    {"name" : "Mark Simulacrum", "email" : "mark.simulacrum@gmail.com", "url" : "https://github.com/Mark-Simulacrum"}
+    {
+      "name": "Mark Simulacrum",
+      "email": "mark.simulacrum@gmail.com",
+      "url": "https://github.com/Mark-Simulacrum"
+    }
   ],
   "title": "spromise",
   "description": "Small Promise",
@@ -34,13 +38,15 @@
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.13",
     "grunt-contrib-connect": "~0.8.0",
+    "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-requirejs": "~0.4.1",
     "grunt-mocha": "~0.4.11",
+    "jshint-stylish": "^1.0.0",
     "promises-aplus-tests": ""
   },
   "scripts": {
     "prepublish": "bower install && grunt build --verbose",
-    "test": "node tests/promises-aplus-tests.js && grunt test"
+    "test": "grunt lint && node tests/promises-aplus-tests.js && grunt test"
   },
   "directories": {
     "test": "tests"

--- a/src/all.js
+++ b/src/all.js
@@ -7,7 +7,7 @@ define(function(require, exports, module) {
   "use strict";
 
   var Promise = require("src/promise"),
-      Async   = require("src/async");
+      async   = require("src/async");
 
   function _result(input, args, context) {
     if (typeof(input) === "function") {
@@ -61,7 +61,7 @@ define(function(require, exports, module) {
     }
 
     // Process the promises and callbacks
-    Async(processQueue);
+    async(processQueue);
     return promise;
   }
 

--- a/src/race.js
+++ b/src/race.js
@@ -22,14 +22,18 @@ define(function(require, exports, module) {
       function _resolve() {
         if (!_done) {
           _done = true;
+          /*jshint -W040 */
           resolve.apply(this, arguments);
+          /*jshint +W040 */
         }
       }
 
       function _reject() {
         if (!_done) {
           _done = true;
+          /*jshint -W040 */
           reject.apply(this, arguments);
+          /*jshint +W040 */
         }
       }
     });

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -1,11 +1,10 @@
 {
-  "undef":true,
-  "unused":true,
-  "curly":true,
-  "indent":2,
-  "devel":true,
-  //"laxcasebreak":true,
-  "globals":{
+  "undef": true,
+  "unused": true,
+  "curly": true,
+  "indent": 2,
+  "devel": true,
+  "globals": {
     "require": true,
     "define": true,
     "$": true,

--- a/tests/SpecRunner.js
+++ b/tests/SpecRunner.js
@@ -1,4 +1,5 @@
-define(function(require, exports, module) {
+/* global mocha */
+define(function(require/*, exports, module*/) {
   var $    = require("jquery"),
       chai = require("chai");
 

--- a/tests/requirejs-config.js
+++ b/tests/requirejs-config.js
@@ -1,3 +1,4 @@
+/*global requirejs*/
 requirejs.config({
   "baseUrl": "../",
   "paths": {

--- a/tests/specs/all.js
+++ b/tests/specs/all.js
@@ -1,4 +1,4 @@
-define(function (require, exports, module) {
+define(function (require/*, exports, module*/) {
   var promise = require("src/promise"),
       all     = require("src/all");
 
@@ -36,7 +36,7 @@ define(function (require, exports, module) {
       var deferred2 = promise.reject("reject promise2");
       var result    = promise.defer();
 
-      all([deferred1, deferred2]).then(function(reason) {
+      all([deferred1, deferred2]).then(function(/*reason*/) {
         expect("Failure was expected").to.equal(true);
         result.resolve();
       }, function(reason) {

--- a/tests/specs/async.js
+++ b/tests/specs/async.js
@@ -1,4 +1,4 @@
-define(function(require, exports, module) {
+define(function(require/*, exports, module*/) {
   var async   = require("src/async"),
       Promise = require("src/promise");
 

--- a/tests/specs/build.js
+++ b/tests/specs/build.js
@@ -1,4 +1,4 @@
-define(function(require, exports, module) {
+define(function(require/*, exports, module*/) {
   var Promise = require("dist/spromise-debug");
 
   describe("Build suite test promise", function() {

--- a/tests/specs/promise.js
+++ b/tests/specs/promise.js
@@ -1,4 +1,4 @@
-define(function(require, exports, module) {
+define(function(require/*, exports, module*/) {
   var Promise = require("src/promise"),
       Timer   = require("tests/timer");
 

--- a/tests/specs/race.js
+++ b/tests/specs/race.js
@@ -1,4 +1,4 @@
-define(function(require, exports, module) {
+define(function(require/*, exports, module*/) {
   var Race    = require("src/race"),
       Promise = require("src/promise");
 

--- a/tests/specs/when.js
+++ b/tests/specs/when.js
@@ -1,4 +1,4 @@
-define(function(require, exports, module) {
+define(function(require/*, exports, module*/) {
   var promise = require("src/promise"),
       when    = require("src/when");
 
@@ -70,10 +70,13 @@ define(function(require, exports, module) {
       var deferred1 = promise.resolve("resolve promise");
       var result    = promise.defer();
 
-      return when(deferred1, 3.14).then(function(result1, result2) {
+      when(deferred1, 3.14).then(function(result1, result2) {
         expect(result1).to.equal("resolve promise");
         expect(result2).to.equal(3.14);
+        result.resolve();
       });
+
+      return result;
     });
 
 


### PR DESCRIPTION
Adds Grunt task `lint` and fixes all JSHint errors currently in code.

Fixes #17.

The `lint` task is run in `npm test`, before all other (A+ promises unit test and `grunt test`) tests because it should take the shortest amount of time - a early fail, sort of.
