### PR TITLE
Remove extra information from README now that it is present on the wiki.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Run the following command in the terminal:
 
 ```
 $ npm install
-$ grunt
 ```
 
 ## Tests


### PR DESCRIPTION
- Change test results to list those from TravisCI instead of @MiguelCastillo's computer.
- Update download link version.

I have not moved the download, build, and install information as I consider that to be fine (and better) in the README than on the wiki, because the README is used by `npmjs.com` (for example) to provide information about the package. I've also updated the Table of contents to match the new contents.

The API documentation has been moved, see it [here](https://github.com/MiguelCastillo/spromise/wiki/API)
