### PR TITLE
`arguments`has length property, no need to convert to array.

### DIFF
--- a/tests/specs/race.js
+++ b/tests/specs/race.js
@@ -41,7 +41,7 @@ define(function(require/*, exports, module*/) {
 
         it("then race is resolve with only one parameter", function() {
           return Race([p1, p2]).done(function() {
-            expect(Array.prototype.slice.call(arguments).length).to.equal(1);
+            expect(arguments.length).to.equal(1);
           });
         });
 
@@ -63,7 +63,7 @@ define(function(require/*, exports, module*/) {
         it("then race is resolve with only one parameter", function() {
           return Promise(function(resolve) {
             Race([p1, p2]).fail(function() {
-              expect(Array.prototype.slice.call(arguments).length).to.equal(1);
+              expect(arguments.length).to.equal(1);
               resolve();
             });
           });


### PR DESCRIPTION
Small change to tests, to simplify code.
