### PR TITLE
Replace caller function with setTimeout since setTimeout allows last arg...

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -32,6 +32,6 @@ define(function(require, exports, module) {
     nextTick = setTimeout;
   }
 
-  Async.nextTick = nextTick;
+  Async.nextTick = Async;
   module.exports = Async;
 });


### PR DESCRIPTION
...ument to be omitted.

Technically, if we call `nextTick` with 2 arguments (where the last one is not `0`), this would not be identical, but this _might_ improve performance.

Due to the potential regression, we might not want to merge this. Your choice :).
